### PR TITLE
Increase the maximum emoji size to 50kB

### DIFF
--- a/art/emoji/caro/default.nix
+++ b/art/emoji/caro/default.nix
@@ -29,7 +29,7 @@ in
 
       mogrify -resize 256x256\> *.png
 
-      find . -type f -name '*.png' -execdir ${../../../lib/crushpng.sh} {} {}.new 40000 \;
+      find . -type f -name '*.png' -execdir ${../../../lib/crushpng.sh} {} {}.new 50000 \;
       for f in $(find . -type f -name '*.new'); do
         mv $f ${"$"}{f%.new}
       done

--- a/art/emoji/lotte/default.nix
+++ b/art/emoji/lotte/default.nix
@@ -24,7 +24,7 @@
     ln -s ${crushpng {
       inherit name;
       src = resized name;
-      maxsize = 40000;
+      maxsize = 50000;
     }} $out/${name}.png
   '';
   emoji = [

--- a/lib/mkPleromaEmoji.nix
+++ b/lib/mkPleromaEmoji.nix
@@ -32,7 +32,7 @@ in
         bsdtar -xf $src
       '';
       buildPhase = ''
-        find . -type f -name '*.png' -execdir ${./crushpng.sh} {} {}.new 40000 \;
+        find . -type f -name '*.png' -execdir ${./crushpng.sh} {} {}.new 50000 \;
         for f in $(find . -type f -name '*.new'); do
           mv $f ${"$"}{f%.new}
         done


### PR DESCRIPTION
I thought the limit imposed by mastotodon < 4.0 was 40kB but it’s 50kB
